### PR TITLE
Improve intensity calculation when max contributions > 255

### DIFF
--- a/internal/contribution_graph.go
+++ b/internal/contribution_graph.go
@@ -104,7 +104,7 @@ func (g *ContributionGraph) intensity(r ContributionRecord) uint8 {
 	if maxCount == 0 {
 		return 0
 	}
-	return uint8(255.0 / maxCount * r.Count)
+	return uint8((maxCount * r.Count) / 255)
 }
 
 var (


### PR DESCRIPTION
Hi 👋 Thanks for this very cool software. We want to use it in @epiverse-trace and ran into some issues when implementing. Specifically, we ran into the issue of a contribution graph looking like this:

![](https://raw.githubusercontent.com/epiverse-trace/.github/b5fb5defcd125b77815c099585a002ee7f2fe52e/contribution-graph.svg)

After debugging, it seemed like something was going wrong in the computation of the level to which the rectangles belonged, resulting in all of them being categorized as `L0` (no contributions). The tooltip displayed the count correctly. 

I found out that the computation of the intensity was causing this issue, when the maximum contribution count was >255. This PR proposes a fix to the calculation which normalizes the intensity, no matter the max contribution count. 

For our purposes, the contribution graph looks like this after implementing this fix:

![contribution-graph](https://github.com/herdstat/herdstat/assets/2946344/8ff7ca30-dc30-4ef3-82bd-e127ef7c737c)

 I am more than open to feedback - I understand I did not communicate this PR in any way before dropping it in here. I would greatly appreciate your consideration of this PR - although I in no way feel entitled to that and also do not know whether you are maintaining this repository. Thanks in any case 😊 